### PR TITLE
Implement separate idle watchers for AC and battery

### DIFF
--- a/config/idlenesswatchersettings.h
+++ b/config/idlenesswatchersettings.h
@@ -50,6 +50,8 @@ public slots:
 private slots:
     void minutesChanged(int newVal);
     void secondsChanged(int newVal);
+    void acMinutesChanged(int newVal);
+    void acSecondsChanged(int newVal);
     void saveSettings();
 
 private:

--- a/config/idlenesswatchersettings.ui
+++ b/config/idlenesswatchersettings.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>309</width>
-    <height>177</height>
+    <width>319</width>
+    <height>332</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,82 +15,179 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QGroupBox" name="idlenessWatcherGroupBox">
-     <property name="title">
-      <string>Enab&amp;le Idleness Watcher</string>
+    <widget class="QGroupBox" name="idlenessWatcherSettingsGroupBox">
+     <property name="flat">
+      <bool>false</bool>
      </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-     <layout class="QFormLayout" name="formLayout">
-      <property name="fieldGrowthPolicy">
-       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-      </property>
-      <property name="labelAlignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="idleTimeLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QGroupBox" name="idlenessWatcherGroupBox">
+        <property name="title">
+         <string>E&amp;nable Idleness Watcher on Battery</string>
         </property>
-        <property name="text">
-         <string>When idle then:</string>
+        <property name="flat">
+         <bool>true</bool>
         </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        <property name="checkable">
+         <bool>true</bool>
         </property>
+        <layout class="QFormLayout" name="formLayout">
+         <property name="fieldGrowthPolicy">
+          <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+         </property>
+         <property name="labelAlignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+         <item row="0" column="0">
+          <widget class="QLabel" name="idleTimeLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>When idle then:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="idleActionComboBox"/>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="idleActionLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Idle time:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QSpinBox" name="idleTimeMinutesSpinBox">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="suffix">
+            <string> minutes</string>
+           </property>
+           <property name="maximum">
+            <number>999</number>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QSpinBox" name="idleTimeSecondsSpinBox">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="suffix">
+            <string> seconds</string>
+           </property>
+           <property name="minimum">
+            <number>-1</number>
+           </property>
+           <property name="maximum">
+            <number>60</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="idleActionComboBox"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="idleActionLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+      <item>
+       <widget class="QGroupBox" name="idlenessAcWatcherGroupBox">
+        <property name="title">
+         <string>Enable Idleness Wa&amp;tcher on AC</string>
         </property>
-        <property name="text">
-         <string>Idle time:</string>
+        <property name="flat">
+         <bool>true</bool>
         </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        <property name="checkable">
+         <bool>true</bool>
         </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QSpinBox" name="idleTimeMinutesSpinBox">
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-        <property name="suffix">
-         <string> minutes</string>
-        </property>
-        <property name="maximum">
-         <number>999</number>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QSpinBox" name="idleTimeSecondsSpinBox">
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-        <property name="suffix">
-         <string> seconds</string>
-        </property>
-        <property name="minimum">
-         <number>-1</number>
-        </property>
-        <property name="maximum">
-         <number>60</number>
-        </property>
+        <layout class="QFormLayout" name="formLayout_2">
+         <property name="fieldGrowthPolicy">
+          <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+         </property>
+         <property name="labelAlignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+         <item row="0" column="0">
+          <widget class="QLabel" name="idleAcTimeLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>When idle then:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="idleAcActionComboBox"/>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="idleAcActionLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Idle time:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QSpinBox" name="idleAcTimeMinutesSpinBox">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="suffix">
+            <string> minutes</string>
+           </property>
+           <property name="maximum">
+            <number>999</number>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QSpinBox" name="idleAcTimeSecondsSpinBox">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="suffix">
+            <string> seconds</string>
+           </property>
+           <property name="minimum">
+            <number>-1</number>
+           </property>
+           <property name="maximum">
+            <number>60</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>

--- a/config/powermanagementsettings.cpp
+++ b/config/powermanagementsettings.cpp
@@ -35,6 +35,7 @@ namespace PowerManagementSettingsConstants
     const QString ENABLE_BATTERY_WATCHER_KEY = "enableBatteryWatcher";
     const QString ENABLE_LID_WATCHER_KEY = "enableLidWatcher";
     const QString ENABLE_IDLENESS_WATCHER_KEY = "enableIdlenessWatcher";
+    const QString ENABLE_IDLENESS_AC_WATCHER_KEY = "enableIdlenessAcWatcher";
     const QString LID_CLOSED_ACTION_KEY = "lidClosedAction";
     const QString LID_CLOSED_AC_ACTION_KEY = "lidClosedAcAction";
     const QString LID_CLOSED_EXT_MON_ACTION_KEY = "lidClosedExtMonAction";
@@ -47,6 +48,8 @@ namespace PowerManagementSettingsConstants
     const QString USE_THEME_ICONS_KEY = "useThemeIcons";
     const QString IDLENESS_ACTION_KEY = "idlenessAction";
     const QString IDLENESS_TIME_SECS_KEY = "idlenessTimeSecs";
+    const QString IDLENESS_AC_ACTION_KEY = "idlenessAcAction";
+    const QString IDLENESS_AC_TIME_SECS_KEY = "idlenessAcTimeSecs";
 }
 
 using namespace PowerManagementSettingsConstants;
@@ -222,4 +225,35 @@ void PowerManagementSettings::setIdlenessWatcherEnabled(bool idlenessWatcherEnab
     setValue(ENABLE_IDLENESS_WATCHER_KEY, idlenessWatcherEnabled);
 }
 
+int PowerManagementSettings::getIdlenessAcAction()
+{
+    // default to nothing (-1)
+    return value(IDLENESS_AC_ACTION_KEY, -1).toInt();
+}
 
+void PowerManagementSettings::setIdlenessAcAction(int idlenessAcAction)
+{
+    setValue(IDLENESS_AC_ACTION_KEY, idlenessAcAction);
+}
+
+int PowerManagementSettings::getIdlenessAcTimeSecs()
+{
+    // default to 15 minutes
+    return value(IDLENESS_AC_TIME_SECS_KEY, 900).toInt();
+}
+
+void PowerManagementSettings::setIdlenessAcTimeSecs(int idlenessAcTimeSecs)
+{
+    setValue(IDLENESS_AC_TIME_SECS_KEY, idlenessAcTimeSecs);
+}
+
+
+bool PowerManagementSettings::isIdlenessAcWatcherEnabled()
+{
+    return value(ENABLE_IDLENESS_AC_WATCHER_KEY, false).toBool();
+}
+
+void PowerManagementSettings::setIdlenessAcWatcherEnabled(bool idlenessAcWatcherEnabled)
+{
+    setValue(ENABLE_IDLENESS_AC_WATCHER_KEY, idlenessAcWatcherEnabled);
+}

--- a/config/powermanagementsettings.h
+++ b/config/powermanagementsettings.h
@@ -89,6 +89,15 @@ public:
 
     bool isIdlenessWatcherEnabled();
     void setIdlenessWatcherEnabled(bool idlenessWatcherEnabled);
+
+    int getIdlenessAcAction();
+    void setIdlenessAcAction(int idlenessAcAction);
+
+    int getIdlenessAcTimeSecs();
+    void setIdlenessAcTimeSecs(int idlenessAcTimeSecs);
+
+    bool isIdlenessAcWatcherEnabled();
+    void setIdlenessAcWatcherEnabled(bool idlenessAcWatcherEnabled);
 };
 
 

--- a/src/idlenesswatcher.h
+++ b/src/idlenesswatcher.h
@@ -27,6 +27,7 @@
 
 #include "../config/powermanagementsettings.h"
 #include "watcher.h"
+#include "lid.h"
 
 class IdlenessWatcher : public Watcher
 {
@@ -43,6 +44,9 @@ private slots:
 
 private:
     PowerManagementSettings mPSettings;
+    Lid mLid;
+    int mBatteryId;
+    int mAcId;
 };
 
 #endif // IDLENESSWATCHER_H


### PR DESCRIPTION
When I attach my laptop to AC and an external monitor in my office, I usually do not want it to go sleep after being idle for a few minutes. But I do want it to suspend when on battery. Therefore, I added a complete second set of options to the idle watcher, so now there are two, one for battery and one for AC.

The implementation is pretty much copy & paste, so please do not take it too seriously. I see it as a starting point for a discussion on whether this feature (or something similar) should be implemented at all (and how) ;)
