### PR TITLE
Fix the unit for battery temperature

### DIFF
--- a/src/batteryinfoframe.cpp
+++ b/src/batteryinfoframe.cpp
@@ -66,5 +66,5 @@ void BatteryInfoFrame::onBatteryChanged()
     mUi->energyValue->setText(QString::fromLatin1("%1 Wh (%2 %)").arg(mBattery->energy(), 0, 'f', 2).arg(mBattery->chargePercent()));
     mUi->energyRateValue->setText(QString::fromLatin1("%1 W").arg(mBattery->energyRate(), 0, 'f', 2));
     mUi->voltageValue->setText(QString::fromLatin1("%1 V").arg(mBattery->voltage(), 0, 'f', 2));
-    mUi->temperatureValue->setText(QString::fromLatin1("%1 ºC").arg(mBattery->temperature()));
+    mUi->temperatureValue->setText(QString::fromUtf8("%1 ºC").arg(mBattery->temperature()));
 }


### PR DESCRIPTION
Before the fix:
![before](https://user-images.githubusercontent.com/1937689/50293949-bc82fe00-04af-11e9-942e-e9f639c59803.png)
The unit for temperature should be `ºC` instead of `ÂºC`.