### PR TITLE
Add option (disabled by default) to disable idle watcher on fullscreen.

### DIFF
--- a/config/idlenesswatchersettings.cpp
+++ b/config/idlenesswatchersettings.cpp
@@ -73,7 +73,7 @@ void IdlenessWatcherSettings::mConnectSignals()
     connect(mUi->idleTimeBacklightTimeEdit, SIGNAL(timeChanged(const QTime &)), SLOT(saveSettings()));
     connect(mUi->onBatteryDischargingCheckBox, SIGNAL(toggled(bool)), SLOT(saveSettings()));
 
-    connect(mUi->disableIdlenessFullscreenBox, SIGNAL(toggled(bool)), this, SLOT(saveSettings()));
+    connect(mUi->disableIdlenessFullscreenBox, &QCheckBox::toggled, this, &IdlenessWatcherSettings::saveSettings);
 }
 
 void IdlenessWatcherSettings::mDisconnectSignals()

--- a/config/idlenesswatchersettings.cpp
+++ b/config/idlenesswatchersettings.cpp
@@ -90,7 +90,7 @@ void IdlenessWatcherSettings::mDisconnectSignals()
     disconnect(mUi->backlightSlider, SIGNAL(valueChanged(int)), this, SLOT(saveSettings()));
     disconnect(mUi->idleTimeBacklightTimeEdit, SIGNAL(timeChanged(const QTime &)), this, SLOT(saveSettings()));
     disconnect(mUi->onBatteryDischargingCheckBox, SIGNAL(toggled(bool)), this, SLOT(saveSettings()));
-    disconnect(mUi->disableIdlenessFullscreenBox, SIGNAL(toggled(bool)), this, SLOT(saveSettings()));
+    disconnect(mUi->disableIdlenessFullscreenBox, &QCheckBox::toggled, this, &IdlenessWatcherSettings::saveSettings);
 }
 
 IdlenessWatcherSettings::~IdlenessWatcherSettings()

--- a/config/idlenesswatchersettings.cpp
+++ b/config/idlenesswatchersettings.cpp
@@ -72,6 +72,8 @@ void IdlenessWatcherSettings::mConnectSignals()
     connect(mUi->backlightSlider, SIGNAL(valueChanged(int)), SLOT(saveSettings()));
     connect(mUi->idleTimeBacklightTimeEdit, SIGNAL(timeChanged(const QTime &)), SLOT(saveSettings()));
     connect(mUi->onBatteryDischargingCheckBox, SIGNAL(toggled(bool)), SLOT(saveSettings()));
+
+    connect(mUi->disableIdlenessFullscreenBox, SIGNAL(toggled(bool)), this, SLOT(saveSettings()));
 }
 
 void IdlenessWatcherSettings::mDisconnectSignals()
@@ -88,6 +90,7 @@ void IdlenessWatcherSettings::mDisconnectSignals()
     disconnect(mUi->backlightSlider, SIGNAL(valueChanged(int)), this, SLOT(saveSettings()));
     disconnect(mUi->idleTimeBacklightTimeEdit, SIGNAL(timeChanged(const QTime &)), this, SLOT(saveSettings()));
     disconnect(mUi->onBatteryDischargingCheckBox, SIGNAL(toggled(bool)), this, SLOT(saveSettings()));
+    disconnect(mUi->disableIdlenessFullscreenBox, SIGNAL(toggled(bool)), this, SLOT(saveSettings()));
 }
 
 IdlenessWatcherSettings::~IdlenessWatcherSettings()
@@ -116,6 +119,7 @@ void IdlenessWatcherSettings::loadSettings()
         mUi->backlightSlider->setValue(mSettings.getBacklight());
         mUi->onBatteryDischargingCheckBox->setChecked(mSettings.isIdlenessBacklightOnBatteryDischargingEnabled());
     }
+    mUi->disableIdlenessFullscreenBox->setChecked(mSettings.isDisableIdlenessWhenFullscreenEnabled());
     mConnectSignals();
 }
 
@@ -168,6 +172,7 @@ void IdlenessWatcherSettings::saveSettings()
     mSettings.setIdlenessBacklightTime(mUi->idleTimeBacklightTimeEdit->time());
     mSettings.setBacklight(mUi->backlightSlider->value());
     mSettings.setIdlenessBacklightOnBatteryDischargingEnabled(mUi->onBatteryDischargingCheckBox->isChecked());
+    mSettings.setDisableIdlenessWhenFullscreen(mUi->disableIdlenessFullscreenBox->isChecked());
 }
 
 void IdlenessWatcherSettings::backlightCheckButtonPressed()

--- a/config/idlenesswatchersettings.ui
+++ b/config/idlenesswatchersettings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>393</width>
-    <height>320</height>
+    <height>410</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -172,6 +172,13 @@
        </widget>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="disableIdlenessFullscreenBox">
+     <property name="text">
+      <string>Disable idleness checks when fullscreen</string>
+     </property>
     </widget>
    </item>
   </layout>

--- a/config/powermanagementsettings.cpp
+++ b/config/powermanagementsettings.cpp
@@ -51,6 +51,7 @@ namespace PowerManagementSettingsConstants
     const QString IDLENESS_BACKLIGHT_TIME { QL1S("idlenessTime") };
     const QString IDLENESS_BACKLIGHT { QL1S("backlightIdleness") };
     const QString IDLENESS_BACKLIGHT_ON_BATTERY_DISCHARGING { QL1S("backlightIdlenessOnBatteryDischarging") };
+    const QString DISABLE_IDLENESS_WHEN_FULLSCREEN { QL1S("disableIdlenessWhenFullscreen") };
     const QString POWER_KEY_ACTION { QL1S("powerKeyAction") };
     const QString SUSPEND_KEY_ACTION { QL1S("suspendKeyAction") };
     const QString HIBERNATE_KEY_ACTION { QL1S("hibernateKeyAction") };
@@ -270,6 +271,16 @@ void PowerManagementSettings::setIdlenessBacklightOnBatteryDischargingEnabled(bo
     setValue(IDLENESS_BACKLIGHT_ON_BATTERY_DISCHARGING, enabled);
 }
 
+bool PowerManagementSettings::isDisableIdlenessWhenFullscreenEnabled()
+{
+    return value(DISABLE_IDLENESS_WHEN_FULLSCREEN, false).toBool();
+}
+
+void PowerManagementSettings::setDisableIdlenessWhenFullscreen(bool enabled)
+{
+    setValue(DISABLE_IDLENESS_WHEN_FULLSCREEN, enabled);
+}
+
 int PowerManagementSettings::getPowerKeyAction()
 {
     return value(POWER_KEY_ACTION, LXQt::Power::Action::PowerShutdown).toInt();
@@ -299,3 +310,4 @@ void PowerManagementSettings::setHibernateKeyAction(int action)
 {
     setValue(HIBERNATE_KEY_ACTION, action);
 }
+

--- a/config/powermanagementsettings.h
+++ b/config/powermanagementsettings.h
@@ -103,6 +103,9 @@ public:
     bool isIdlenessBacklightOnBatteryDischargingEnabled();
     void setIdlenessBacklightOnBatteryDischargingEnabled(bool enabled);
 
+    bool isDisableIdlenessWhenFullscreenEnabled();
+    void setDisableIdlenessWhenFullscreen(bool enabled);
+
     int getPowerKeyAction();
     void setPowerKeyAction(int action);
     

--- a/src/idlenesswatcher.cpp
+++ b/src/idlenesswatcher.cpp
@@ -112,6 +112,7 @@ void IdlenessWatcher::timeoutReached(int identifier,int /*msec*/)
         KWindowInfo info(w, NET::WMState);
         if (info.hasState(NET::FullScreen)) {
             qDebug() << "idleness timeout reached with fullscreen window. Postponing...";
+            KIdleTime::instance()->simulateUserActivity();
             return;
         }
     }

--- a/src/idlenesswatcher.cpp
+++ b/src/idlenesswatcher.cpp
@@ -111,7 +111,6 @@ void IdlenessWatcher::timeoutReached(int identifier,int /*msec*/)
         WId w = KWindowSystem::activeWindow();
         KWindowInfo info(w, NET::WMState);
         if (info.hasState(NET::FullScreen)) {
-            qDebug() << "idleness timeout reached with fullscreen window. Postponing...";
             KIdleTime::instance()->simulateUserActivity();
             return;
         }

--- a/src/idlenesswatcher.cpp
+++ b/src/idlenesswatcher.cpp
@@ -28,6 +28,8 @@
 #include <KIdleTime>
 #include <Solid/Device>
 #include <Solid/Battery>
+#include <KWindowSystem/KWindowSystem>
+#include <KWindowSystem/KWindowInfo>
 #include <QDebug>
 #include <LXQt/lxqtnotification.h>
 #include <QObject>
@@ -42,7 +44,7 @@ IdlenessWatcher::IdlenessWatcher(QObject* parent):
     mDischarging = false;
 
     connect(KIdleTime::instance(),
-            static_cast<void (KIdleTime::*)(int)>(&KIdleTime::timeoutReached),
+            static_cast<void (KIdleTime::*)(int,int)>(&KIdleTime::timeoutReached),
             this,
             &IdlenessWatcher::timeoutReached);
 
@@ -102,8 +104,18 @@ void IdlenessWatcher::setup()
     }
 }
 
-void IdlenessWatcher::timeoutReached(int identifier)
+void IdlenessWatcher::timeoutReached(int identifier,int /*msec*/)
 {
+    // check if disable Idleness when fullscreen is enabled
+    if (mPSettings.isDisableIdlenessWhenFullscreenEnabled()) {
+        WId w = KWindowSystem::activeWindow();
+        KWindowInfo info(w, NET::WMState);
+        if (info.hasState(NET::FullScreen)) {
+            qDebug() << "idleness timeout reached with fullscreen window. Postponing...";
+            return;
+        }
+    }
+
     if(identifier == mIdleWatcher) {
         doAction(mPSettings.getIdlenessAction());
     } else if(identifier == mIdleBacklightWatcher && mBacklightActualValue < 0) {
@@ -163,10 +175,10 @@ void IdlenessWatcher::onBatteryChanged(int, const QString &)
     onSettingsChanged();
 }
 
-
 void IdlenessWatcher::onSettingsChanged()
 {
     KIdleTime::instance()->removeAllIdleTimeouts();
     mIdleWatcher = mIdleBacklightWatcher = -1;
     setup();
 }
+

--- a/src/idlenesswatcher.h
+++ b/src/idlenesswatcher.h
@@ -39,7 +39,7 @@ public:
 
 private Q_SLOTS:
     void setup();
-    void timeoutReached(int identifier);
+    void timeoutReached(int identifier,int msec);
     void resumingFromIdle();
     void onBatteryChanged(int newState, const QString &udi = QString());
     void onSettingsChanged();


### PR DESCRIPTION
Fixes #224
I also removed deprecated KIdleTime::timeoutReached(int) method and
used the actual timeoutReached(int,int) instead.