### PR TITLE
Move to new signal/slot syntax

### DIFF
--- a/config/batterywatchersettings.cpp
+++ b/config/batterywatchersettings.cpp
@@ -49,17 +49,17 @@ BatteryWatcherSettings::BatteryWatcherSettings(QWidget *parent) :
     mChargingIconProducer.updateState(Solid::Battery::Charging);
     mDischargingIconProducer.updateState(Solid::Battery::Discharging);
 
-    connect(mUi->groupBox, SIGNAL(clicked()), this, SLOT(saveSettings()));
-    connect(mUi->actionComboBox, SIGNAL(activated(int)), this, SLOT(saveSettings()));
-    connect(mUi->warningSpinBox, SIGNAL(editingFinished()), this, SLOT(saveSettings()));
-    connect(mUi->levelSpinBox, SIGNAL(editingFinished()), this, SLOT(saveSettings()));
-    connect(mUi->showIconCheckBox, SIGNAL(clicked(bool)), this, SLOT(saveSettings()));
-    connect(mUi->showIconCheckBox, SIGNAL(clicked(bool)), mUi->previewBox, SLOT(setEnabled(bool)));
-    connect(mUi->useThemeIconsCheckBox, SIGNAL(clicked(bool)), this, SLOT(saveSettings()));
-    connect(mUi->useThemeIconsCheckBox, SIGNAL(clicked(bool)), this, SLOT(updatePreview()));
-    connect(mUi->chargeLevelSlider, SIGNAL(valueChanged(int)), this, SLOT(updatePreview()));
-    connect(&mChargingIconProducer, SIGNAL(iconChanged()), this, SLOT(onChargeIconChanged()));
-    connect(&mDischargingIconProducer, SIGNAL(iconChanged()), this, SLOT(onDischargeIconChanged()));
+    connect(mUi->groupBox, &QGroupBox::clicked, this, &BatteryWatcherSettings::saveSettings);
+    connect(mUi->actionComboBox, QOverload<int>::of(&QComboBox::activated), this, &BatteryWatcherSettings::saveSettings);
+    connect(mUi->warningSpinBox, &QSpinBox::editingFinished, this, &BatteryWatcherSettings::saveSettings);
+    connect(mUi->levelSpinBox, &QSpinBox::editingFinished, this, &BatteryWatcherSettings::saveSettings);
+    connect(mUi->showIconCheckBox, &QCheckBox::clicked, this, &BatteryWatcherSettings::saveSettings);
+    connect(mUi->showIconCheckBox, &QCheckBox::clicked, mUi->previewBox, &QGroupBox::setEnabled);
+    connect(mUi->useThemeIconsCheckBox, &QCheckBox::clicked, this, &BatteryWatcherSettings::saveSettings);
+    connect(mUi->useThemeIconsCheckBox, &QCheckBox::clicked, this, &BatteryWatcherSettings::updatePreview);
+    connect(mUi->chargeLevelSlider, &QSlider::valueChanged, this, &BatteryWatcherSettings::updatePreview);
+    connect(&mChargingIconProducer, &IconProducer::iconChanged, this, &BatteryWatcherSettings::onChargeIconChanged);
+    connect(&mDischargingIconProducer, &IconProducer::iconChanged, this, &BatteryWatcherSettings::onDischargeIconChanged);
     updatePreview();
 }
 

--- a/config/idlenesswatchersettings.cpp
+++ b/config/idlenesswatchersettings.cpp
@@ -57,40 +57,44 @@ IdlenessWatcherSettings::IdlenessWatcherSettings(QWidget *parent) :
 
 void IdlenessWatcherSettings::mConnectSignals()
 {
-    connect(mUi->idlenessWatcherGroupBox, SIGNAL(clicked()), SLOT(saveSettings()));
-    connect(mUi->idleActionComboBox, SIGNAL(activated(int)), SLOT(saveSettings()));
-    connect(mUi->idleTimeMinutesSpinBox, SIGNAL(editingFinished()), SLOT(saveSettings()));
-    connect(mUi->idleTimeMinutesSpinBox, SIGNAL(valueChanged(int)), SLOT(minutesChanged(int)));
-    connect(mUi->idleTimeSecondsSpinBox, SIGNAL(valueChanged(int)), SLOT(secondsChanged(int)));
+    connect(mUi->idlenessWatcherGroupBox,          &QGroupBox::clicked,                         this, &IdlenessWatcherSettings::saveSettings);
+    connect(mUi->idleActionComboBox,               QOverload<int>::of(&QComboBox::activated),   this, &IdlenessWatcherSettings::saveSettings);
+    connect(mUi->idleTimeMinutesSpinBox,           &QSpinBox::editingFinished,                  this, &IdlenessWatcherSettings::saveSettings);
+    connect(mUi->idleTimeMinutesSpinBox,           QOverload<int>::of(&QSpinBox::valueChanged), this, &IdlenessWatcherSettings::minutesChanged);
+    connect(mUi->idleTimeSecondsSpinBox,           QOverload<int>::of(&QSpinBox::valueChanged), this, &IdlenessWatcherSettings::secondsChanged);
 
-    connect(mUi->idleTimeSecondsSpinBox, SIGNAL(editingFinished()), SLOT(saveSettings()));
+    connect(mUi->idleTimeSecondsSpinBox,           &QSpinBox::editingFinished,                  this, &IdlenessWatcherSettings::saveSettings);
     
-    connect(mUi->checkBacklightButton, SIGNAL(pressed()), SLOT(backlightCheckButtonPressed()));
-    connect(mUi->checkBacklightButton, SIGNAL(released()), SLOT(backlightCheckButtonReleased()));
+    connect(mUi->checkBacklightButton,             &QPushButton::pressed,                       this, &IdlenessWatcherSettings::backlightCheckButtonPressed);
+    connect(mUi->checkBacklightButton,             &QPushButton::released,                      this, &IdlenessWatcherSettings::backlightCheckButtonReleased);
     
-    connect(mUi->idlenessBacklightWatcherGroupBox, SIGNAL(clicked()), SLOT(saveSettings()));
-    connect(mUi->backlightSlider, SIGNAL(valueChanged(int)), SLOT(saveSettings()));
-    connect(mUi->idleTimeBacklightTimeEdit, SIGNAL(timeChanged(const QTime &)), SLOT(saveSettings()));
-    connect(mUi->onBatteryDischargingCheckBox, SIGNAL(toggled(bool)), SLOT(saveSettings()));
+    connect(mUi->idlenessBacklightWatcherGroupBox, &QGroupBox::clicked,                         this, &IdlenessWatcherSettings::saveSettings);
+    connect(mUi->backlightSlider,                  &QSlider::valueChanged,                      this, &IdlenessWatcherSettings::saveSettings);
+    connect(mUi->idleTimeBacklightTimeEdit,        &QTimeEdit::timeChanged,                     this, &IdlenessWatcherSettings::saveSettings);
+    connect(mUi->onBatteryDischargingCheckBox,     &QCheckBox::toggled,                         this, &IdlenessWatcherSettings::saveSettings);
 
-    connect(mUi->disableIdlenessFullscreenBox, &QCheckBox::toggled, this, &IdlenessWatcherSettings::saveSettings);
+    connect(mUi->disableIdlenessFullscreenBox,     &QCheckBox::toggled,                         this, &IdlenessWatcherSettings::saveSettings);
 }
 
 void IdlenessWatcherSettings::mDisconnectSignals()
 {
-    disconnect(mUi->idlenessWatcherGroupBox, SIGNAL(clicked()), this, SLOT(saveSettings()));
-    disconnect(mUi->idleActionComboBox, SIGNAL(activated(int)), this, SLOT(saveSettings()));
-    disconnect(mUi->idleTimeMinutesSpinBox, SIGNAL(editingFinished()), this, SLOT(saveSettings()));
-    disconnect(mUi->idleTimeMinutesSpinBox, SIGNAL(valueChanged(int)), this, SLOT(minutesChanged(int)));
-    disconnect(mUi->idleTimeSecondsSpinBox, SIGNAL(valueChanged(int)), this, SLOT(secondsChanged(int)));
-    disconnect(mUi->idleTimeSecondsSpinBox, SIGNAL(editingFinished()), this, SLOT(saveSettings()));    
-    disconnect(mUi->checkBacklightButton, SIGNAL(pressed()), this, SLOT(backlightCheckButtonPressed()));
-    disconnect(mUi->checkBacklightButton, SIGNAL(released()), this, SLOT(backlightCheckButtonReleased()));    
-    disconnect(mUi->idlenessBacklightWatcherGroupBox, SIGNAL(clicked()), this, SLOT(saveSettings()));
-    disconnect(mUi->backlightSlider, SIGNAL(valueChanged(int)), this, SLOT(saveSettings()));
-    disconnect(mUi->idleTimeBacklightTimeEdit, SIGNAL(timeChanged(const QTime &)), this, SLOT(saveSettings()));
-    disconnect(mUi->onBatteryDischargingCheckBox, SIGNAL(toggled(bool)), this, SLOT(saveSettings()));
-    disconnect(mUi->disableIdlenessFullscreenBox, &QCheckBox::toggled, this, &IdlenessWatcherSettings::saveSettings);
+    disconnect(mUi->idlenessWatcherGroupBox,          &QGroupBox::clicked,                         this, &IdlenessWatcherSettings::saveSettings);
+    disconnect(mUi->idleActionComboBox,               QOverload<int>::of(&QComboBox::activated),   this, &IdlenessWatcherSettings::saveSettings);
+    disconnect(mUi->idleTimeMinutesSpinBox,           &QSpinBox::editingFinished,                  this, &IdlenessWatcherSettings::saveSettings);
+    disconnect(mUi->idleTimeMinutesSpinBox,           QOverload<int>::of(&QSpinBox::valueChanged), this, &IdlenessWatcherSettings::minutesChanged);
+    disconnect(mUi->idleTimeSecondsSpinBox,           QOverload<int>::of(&QSpinBox::valueChanged), this, &IdlenessWatcherSettings::secondsChanged);
+
+    disconnect(mUi->idleTimeSecondsSpinBox,           &QSpinBox::editingFinished,                  this, &IdlenessWatcherSettings::saveSettings);
+
+    disconnect(mUi->checkBacklightButton,             &QPushButton::pressed,                       this, &IdlenessWatcherSettings::backlightCheckButtonPressed);
+    disconnect(mUi->checkBacklightButton,             &QPushButton::released,                      this, &IdlenessWatcherSettings::backlightCheckButtonReleased);
+
+    disconnect(mUi->idlenessBacklightWatcherGroupBox, &QGroupBox::clicked,                         this, &IdlenessWatcherSettings::saveSettings);
+    disconnect(mUi->backlightSlider,                  &QSlider::valueChanged,                      this, &IdlenessWatcherSettings::saveSettings);
+    disconnect(mUi->idleTimeBacklightTimeEdit,        &QTimeEdit::timeChanged,                     this, &IdlenessWatcherSettings::saveSettings);
+    disconnect(mUi->onBatteryDischargingCheckBox,     &QCheckBox::toggled,                         this, &IdlenessWatcherSettings::saveSettings);
+
+    disconnect(mUi->disableIdlenessFullscreenBox,     &QCheckBox::toggled,                         this, &IdlenessWatcherSettings::saveSettings);
 }
 
 IdlenessWatcherSettings::~IdlenessWatcherSettings()

--- a/config/lidwatchersettings.cpp
+++ b/config/lidwatchersettings.cpp
@@ -44,12 +44,12 @@ LidWatcherSettings::LidWatcherSettings(QWidget *parent) :
     fillComboBox(mUi->extMonOnBatteryActionComboBox);
     fillComboBox(mUi->extMonOnAcActionComboBox);
 
-    connect(mUi->lidWatcherSettingsGroupBox, SIGNAL(clicked()), this, SLOT(saveSettings()));
-    connect(mUi->onBatteryActionComboBox, SIGNAL(activated(int)), this, SLOT(saveSettings()));
-    connect(mUi->onAcActionComboBox, SIGNAL(activated(int)), this, SLOT(saveSettings()));
-    connect(mUi->extMonOnBatteryActionComboBox, SIGNAL(activated(int)), this, SLOT(saveSettings()));
-    connect(mUi->extMonOnAcActionComboBox, SIGNAL(activated(int)), this, SLOT(saveSettings()));
-    connect(mUi->extMonGroupBox, SIGNAL(clicked()), this, SLOT(saveSettings()));
+    connect(mUi->lidWatcherSettingsGroupBox, &QGroupBox::clicked, this, &LidWatcherSettings::saveSettings);
+    connect(mUi->onBatteryActionComboBox, QOverload<int>::of(&QComboBox::activated), this, &LidWatcherSettings::saveSettings);
+    connect(mUi->onAcActionComboBox, QOverload<int>::of(&QComboBox::activated), this, &LidWatcherSettings::saveSettings);
+    connect(mUi->extMonOnBatteryActionComboBox, QOverload<int>::of(&QComboBox::activated), this, &LidWatcherSettings::saveSettings);
+    connect(mUi->extMonOnAcActionComboBox, QOverload<int>::of(&QComboBox::activated), this, &LidWatcherSettings::saveSettings);
+    connect(mUi->extMonGroupBox, &QGroupBox::clicked, this, &LidWatcherSettings::saveSettings);
 }
 
 LidWatcherSettings::~LidWatcherSettings()

--- a/config/mainwindow.cpp
+++ b/config/mainwindow.cpp
@@ -38,19 +38,19 @@ MainWindow::MainWindow(QWidget *parent) :
 {
     BatteryWatcherSettings* batteryWatcherSettings = new BatteryWatcherSettings(this);
     addPage(batteryWatcherSettings, tr("Battery"), QSL("battery"));
-    connect(this, SIGNAL(reset()), batteryWatcherSettings, SLOT(loadSettings()));
+    connect(this, &MainWindow::reset, batteryWatcherSettings, &BatteryWatcherSettings::loadSettings);
 
     LidWatcherSettings *lidwatcherSettings = new LidWatcherSettings(this);
     addPage(lidwatcherSettings, tr("Lid"), QSL("laptop-lid"));
-    connect(this, SIGNAL(reset()), lidwatcherSettings, SLOT(loadSettings()));
+    connect(this, &MainWindow::reset, lidwatcherSettings, &LidWatcherSettings::loadSettings);
 
     IdlenessWatcherSettings* idlenessWatcherSettings = new IdlenessWatcherSettings(this);
     addPage(idlenessWatcherSettings, tr("Idle"), (QStringList() << QSL("user-idle") << QSL("user-away")));
-    connect(this, SIGNAL(reset()), idlenessWatcherSettings, SLOT(loadSettings()));
+    connect(this, &MainWindow::reset, idlenessWatcherSettings, &IdlenessWatcherSettings::loadSettings);
 
     PowerKeysSettings* powerKeysSettings = new PowerKeysSettings(this);
     addPage(powerKeysSettings, tr("Power keys"), QSL("system-shutdown"));
-    connect(this, SIGNAL(reset()), powerKeysSettings, SLOT(loadSettings()));
+    connect(this, &MainWindow::reset, powerKeysSettings, &PowerKeysSettings::loadSettings);
 
     emit reset();
 }

--- a/config/powerkeyssettings.cpp
+++ b/config/powerkeyssettings.cpp
@@ -39,16 +39,14 @@ PowerKeysSettings::PowerKeysSettings(QWidget *parent) :
     fillComboBox(mUi->suspendKeyActionComboBox);
     fillComboBox(mUi->hibernateKeyActionComboBox);
 
-    connect(mUi->powerKeyActionComboBox, SIGNAL(activated(int)), this, SLOT(saveSettings()));
-    connect(mUi->suspendKeyActionComboBox, SIGNAL(activated(int)), this, SLOT(saveSettings()));
-    connect(mUi->hibernateKeyActionComboBox, SIGNAL(activated(int)), this, SLOT(saveSettings()));
+    connect(mUi->powerKeyActionComboBox, QOverload<int>::of(&QComboBox::activated), this, &PowerKeysSettings::saveSettings);
+    connect(mUi->suspendKeyActionComboBox, QOverload<int>::of(&QComboBox::activated), this, &PowerKeysSettings::saveSettings);
+    connect(mUi->hibernateKeyActionComboBox, QOverload<int>::of(&QComboBox::activated), this, &PowerKeysSettings::saveSettings);
 }
-
 
 PowerKeysSettings::~PowerKeysSettings()
 {
 }
-
 
 void PowerKeysSettings::loadSettings()
 {
@@ -56,7 +54,6 @@ void PowerKeysSettings::loadSettings()
     setComboBoxToValue(mUi->suspendKeyActionComboBox, mSettings.getSuspendKeyAction());
     setComboBoxToValue(mUi->hibernateKeyActionComboBox, mSettings.getHibernateKeyAction());
 }
-
 
 void PowerKeysSettings::saveSettings()
 {

--- a/src/batteryinfoframe.cpp
+++ b/src/batteryinfoframe.cpp
@@ -49,8 +49,8 @@ BatteryInfoFrame::BatteryInfoFrame(Solid::Battery *battery) :
         vendor = QSL("Unknown");
     mUi->vendorValue->setText(vendor);
 
-    connect(mBattery, SIGNAL(energyChanged(double, const QString)), this, SLOT(onBatteryChanged()));
-    connect(mBattery, SIGNAL(chargeStateChanged(int, const QString)), this, SLOT(onBatteryChanged()));
+    connect(mBattery, &Solid::Battery::energyChanged, this, &BatteryInfoFrame::onBatteryChanged);
+    connect(mBattery, &Solid::Battery::chargeStateChanged, this, &BatteryInfoFrame::onBatteryChanged);
     onBatteryChanged();
 }
 

--- a/src/batterywatcher.cpp
+++ b/src/batterywatcher.cpp
@@ -64,7 +64,8 @@ BatteryWatcher::BatteryWatcher(QObject *parent) : Watcher(parent)
 
     mBatteryInfoDialog = new BatteryInfoDialog(mBatteries);
 
-    connect(&mSettings, SIGNAL(settingsChanged()), this, SLOT(settingsChanged()));
+    connect(&mSettings, &PowerManagementSettings::settingsChanged, this, &BatteryWatcher::settingsChanged);
+    // connect(LXQt::Settings::globalSettings(), &LXQt::GlobalSettings::iconThemeChanged, this, &BatteryWatcher::settingsChanged);
     connect(LXQt::Settings::globalSettings(), SIGNAL(iconThemeChanged()), this, SLOT(settingsChanged()));
 
     settingsChanged();
@@ -135,7 +136,7 @@ void BatteryWatcher::batteryChanged()
 
             notification->update();
 
-            QTimer::singleShot(200, this, SLOT(batteryChanged()));
+            QTimer::singleShot(200, this, &BatteryWatcher::batteryChanged);
         }
         else
         {
@@ -170,9 +171,8 @@ void BatteryWatcher::settingsChanged()
         for (Solid::Battery *battery : qAsConst(mBatteries))
         {
             mTrayIcons.append(new TrayIcon(battery, this));
-            connect(mTrayIcons.last(), SIGNAL(toggleShowInfo()), mBatteryInfoDialog, SLOT(toggleShow()));
+            connect(mTrayIcons.last(), &TrayIcon::toggleShowInfo, mBatteryInfoDialog, &BatteryInfoDialog::toggleShow);
             mTrayIcons.last()->show();
         }
     }
 }
-

--- a/src/batterywatcher.cpp
+++ b/src/batterywatcher.cpp
@@ -65,8 +65,7 @@ BatteryWatcher::BatteryWatcher(QObject *parent) : Watcher(parent)
     mBatteryInfoDialog = new BatteryInfoDialog(mBatteries);
 
     connect(&mSettings, &PowerManagementSettings::settingsChanged, this, &BatteryWatcher::settingsChanged);
-    // connect(LXQt::Settings::globalSettings(), &LXQt::GlobalSettings::iconThemeChanged, this, &BatteryWatcher::settingsChanged);
-    connect(LXQt::Settings::globalSettings(), SIGNAL(iconThemeChanged()), this, SLOT(settingsChanged()));
+    connect(LXQt::Settings::globalSettings(), &LXQt::GlobalSettings::iconThemeChanged, this, &BatteryWatcher::settingsChanged);
 
     settingsChanged();
     batteryChanged();

--- a/src/batterywatcher.h
+++ b/src/batterywatcher.h
@@ -37,6 +37,7 @@
 class BatteryWatcher : public Watcher
 {
     Q_OBJECT
+
 public:
     explicit BatteryWatcher(QObject *parent = nullptr);
     ~BatteryWatcher() override;

--- a/src/iconproducer.cpp
+++ b/src/iconproducer.cpp
@@ -19,7 +19,7 @@ IconProducer::IconProducer(Solid::Battery *battery, QObject *parent) : QObject(p
 {
     connect(battery, &Solid::Battery::chargeStateChanged, this, &IconProducer::updateState);
     connect(battery, &Solid::Battery::chargePercentChanged, this, &IconProducer::updateChargePercent);
-    connect(&mSettings, SIGNAL(settingsChanged()), this, SLOT(update()));
+    connect(&mSettings, &PowerManagementSettings::settingsChanged, this, &IconProducer::update);
 
     mChargePercent = battery->chargePercent();
     mState = battery->chargeState();

--- a/src/lidwatcher.cpp
+++ b/src/lidwatcher.cpp
@@ -40,7 +40,7 @@
 LidWatcher::LidWatcher(QObject *parent) : Watcher(parent)
 {
     inhibitSystemdLogin();
-    connect(&mLid, SIGNAL(changed(bool)), this, SLOT(lidChanged(bool)));
+    connect(&mLid, &Lid::changed, this, &LidWatcher::lidChanged);
 }
 
 LidWatcher::~LidWatcher(){

--- a/src/powerbutton.cpp
+++ b/src/powerbutton.cpp
@@ -72,21 +72,21 @@ PowerButton::PowerButton(QObject *parent) : Watcher(parent)
         QStringLiteral("/powermanager/keypoweroff"), tr("Power off key action"), this);
 
     if (mKeyPowerButton) {
-        connect(mKeyPowerButton, SIGNAL(activated()), this, SLOT(handleShortcutPoweroff()));
+        connect(mKeyPowerButton, &GlobalKeyShortcut::Action::activated, this, &PowerButton::handleShortcutPoweroff);
     }
     
     mKeySuspendButton = GlobalKeyShortcut::Client::instance()->addAction(QStringLiteral("XF86Suspend"), 
         QStringLiteral("/powermanager/keysuspend"), tr("Suspend key action"), this);
 
     if (mKeySuspendButton) {
-        connect(mKeySuspendButton, SIGNAL(activated()), this, SLOT(handleShortcutSuspend()));
+        connect(mKeySuspendButton, &GlobalKeyShortcut::Action::activated, this, &PowerButton::handleShortcutSuspend);
     }
     
     mKeyHibernateButton = GlobalKeyShortcut::Client::instance()->addAction(QStringLiteral("XF86Sleep"), 
         QStringLiteral("/powermanager/keyhibernate"), tr("Hibernate key action"), this);
 
     if (mKeyHibernateButton) {
-        connect(mKeyHibernateButton, SIGNAL(activated()), this, SLOT(handleShortcutHibernate()));
+        connect(mKeyHibernateButton, &GlobalKeyShortcut::Action::activated, this, &PowerButton::handleShortcutHibernate);
     }
 }
 

--- a/src/powermanagementd.cpp
+++ b/src/powermanagementd.cpp
@@ -45,7 +45,7 @@ PowerManagementd::PowerManagementd() :
         mIdlenesswatcherd(nullptr),
         mSettings()
  {
-    connect(&mSettings, SIGNAL(settingsChanged()), this, SLOT(settingsChanged()));
+    connect(&mSettings, &PowerManagementSettings::settingsChanged, this, &PowerManagementd::settingsChanged);
     settingsChanged();
 
     if (mSettings.getRunCheckLevel() < CURRENT_RUNCHECK_LEVEL)
@@ -116,6 +116,6 @@ void PowerManagementd::performRunCheck()
     mNotification.setBody(tr("You are running LXQt Power Management for the first time.\nYou can configure it from settings... "));
     mNotification.setActions(QStringList() << tr("Configure..."));
     mNotification.setTimeout(10000);
-    connect(&mNotification, SIGNAL(actionActivated(int)), SLOT(runConfigure()));
+    connect(&mNotification, &LXQt::Notification::actionActivated, this, &PowerManagementd::runConfigure);
     mNotification.update();
 }

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -52,18 +52,17 @@ TrayIcon::TrayIcon(Solid::Battery *battery, QObject *parent)
     connect(mBattery, &Solid::Battery::chargeStateChanged, this, &TrayIcon::updateTooltip);
     updateTooltip();
 
-    connect(&mIconProducer, SIGNAL(iconChanged()), this, SLOT(iconChanged()));
+    connect(&mIconProducer, &IconProducer::iconChanged, this, &TrayIcon::iconChanged);
     iconChanged();
 
-    connect(this, SIGNAL(activated(QSystemTrayIcon::ActivationReason)),
-            SLOT(onActivated(QSystemTrayIcon::ActivationReason)));
+    connect(this, &TrayIcon::activated, this, &TrayIcon::onActivated);
 
     mContextMenu.addAction(XdgIcon::fromTheme(QStringLiteral("configure")), tr("Configure"),
-                           this, SLOT(onConfigureTriggered()));
+                           this, &TrayIcon::onConfigureTriggered);
     mContextMenu.addAction(XdgIcon::fromTheme(QStringLiteral("help-about")), tr("About"),
-                           this, SLOT(onAboutTriggered()));
+                           this, &TrayIcon::onAboutTriggered);
     mContextMenu.addAction(XdgIcon::fromTheme(QStringLiteral("edit-delete")), tr("Disable icon"),
-                           this, SLOT(onDisableIconTriggered()));
+                           this, &TrayIcon::onDisableIconTriggered);
     setContextMenu(&mContextMenu);
 }
 


### PR DESCRIPTION
I'm having a problem in one line (src/batterywatcher.cpp +68), cause of LXQt::Settings::GlobalSettings. With new syntax code doesn't link. I'm unsure about.