### PR TITLE
Fixed reading of legacy setting

### DIFF
--- a/config/idlenesswatchersettings.cpp
+++ b/config/idlenesswatchersettings.cpp
@@ -54,7 +54,7 @@ IdlenessWatcherSettings::IdlenessWatcherSettings(QWidget *parent) :
     } else {
         mBacklightActualValue = mBacklight->getBacklight();
     }
-    
+
     mConnectSignals();
 }
 
@@ -63,16 +63,16 @@ void IdlenessWatcherSettings::mConnectSignals()
 {
     connect(mUi->idlenessWatcherGroupBox,          &QGroupBox::clicked,                         this, &IdlenessWatcherSettings::saveSettings);
     connect(mUi->idleACActionComboBox,             QOverload<int>::of(&QComboBox::activated),   this, &IdlenessWatcherSettings::saveSettings);
-    connect(mUi->idleACTimeEdit,                   &QTimeEdit::timeChanged,                     this, &IdlenessWatcherSettings::saveSettings);
+    connect(mUi->idleACTimeEdit,                   &QTimeEdit::editingFinished,                 this, &IdlenessWatcherSettings::saveSettings);
     connect(mUi->idleBatteryActionComboBox,        QOverload<int>::of(&QComboBox::activated),   this, &IdlenessWatcherSettings::saveSettings);
-    connect(mUi->idleBatteryTimeEdit,              &QTimeEdit::timeChanged,                     this, &IdlenessWatcherSettings::saveSettings);
-    
+    connect(mUi->idleBatteryTimeEdit,              &QTimeEdit::editingFinished,                 this, &IdlenessWatcherSettings::saveSettings);
+
     connect(mUi->checkBacklightButton,             &QPushButton::pressed,                       this, &IdlenessWatcherSettings::backlightCheckButtonPressed);
     connect(mUi->checkBacklightButton,             &QPushButton::released,                      this, &IdlenessWatcherSettings::backlightCheckButtonReleased);
-    
+
     connect(mUi->idlenessBacklightWatcherGroupBox, &QGroupBox::clicked,                         this, &IdlenessWatcherSettings::saveSettings);
     connect(mUi->backlightSlider,                  &QSlider::valueChanged,                      this, &IdlenessWatcherSettings::saveSettings);
-    connect(mUi->idleTimeBacklightTimeEdit,        &QTimeEdit::timeChanged,                     this, &IdlenessWatcherSettings::saveSettings);
+    connect(mUi->idleTimeBacklightTimeEdit,        &QTimeEdit::editingFinished,                 this, &IdlenessWatcherSettings::saveSettings);
     connect(mUi->onBatteryDischargingCheckBox,     &QCheckBox::toggled,                         this, &IdlenessWatcherSettings::saveSettings);
 
     connect(mUi->disableIdlenessFullscreenBox,     &QCheckBox::toggled,                         this, &IdlenessWatcherSettings::saveSettings);
@@ -82,16 +82,16 @@ void IdlenessWatcherSettings::mDisconnectSignals()
 {
     disconnect(mUi->idlenessWatcherGroupBox,          &QGroupBox::clicked,                         this, &IdlenessWatcherSettings::saveSettings);
     disconnect(mUi->idleACActionComboBox,             QOverload<int>::of(&QComboBox::activated),   this, &IdlenessWatcherSettings::saveSettings);
-    disconnect(mUi->idleACTimeEdit,                   &QTimeEdit::timeChanged,                     this, &IdlenessWatcherSettings::saveSettings);
+    disconnect(mUi->idleACTimeEdit,                   &QTimeEdit::editingFinished,                 this, &IdlenessWatcherSettings::saveSettings);
     disconnect(mUi->idleBatteryActionComboBox,        QOverload<int>::of(&QComboBox::activated),   this, &IdlenessWatcherSettings::saveSettings);
-    disconnect(mUi->idleBatteryTimeEdit,              &QTimeEdit::timeChanged,                     this, &IdlenessWatcherSettings::saveSettings);
+    disconnect(mUi->idleBatteryTimeEdit,              &QTimeEdit::editingFinished,                 this, &IdlenessWatcherSettings::saveSettings);
 
     disconnect(mUi->checkBacklightButton,             &QPushButton::pressed,                       this, &IdlenessWatcherSettings::backlightCheckButtonPressed);
     disconnect(mUi->checkBacklightButton,             &QPushButton::released,                      this, &IdlenessWatcherSettings::backlightCheckButtonReleased);
 
     disconnect(mUi->idlenessBacklightWatcherGroupBox, &QGroupBox::clicked,                         this, &IdlenessWatcherSettings::saveSettings);
     disconnect(mUi->backlightSlider,                  &QSlider::valueChanged,                      this, &IdlenessWatcherSettings::saveSettings);
-    disconnect(mUi->idleTimeBacklightTimeEdit,        &QTimeEdit::timeChanged,                     this, &IdlenessWatcherSettings::saveSettings);
+    disconnect(mUi->idleTimeBacklightTimeEdit,        &QTimeEdit::editingFinished,                 this, &IdlenessWatcherSettings::saveSettings);
     disconnect(mUi->onBatteryDischargingCheckBox,     &QCheckBox::toggled,                         this, &IdlenessWatcherSettings::saveSettings);
 
     disconnect(mUi->disableIdlenessFullscreenBox,     &QCheckBox::toggled,                         this, &IdlenessWatcherSettings::saveSettings);
@@ -106,13 +106,13 @@ void IdlenessWatcherSettings::loadSettings()
 {
     mDisconnectSignals();
     mUi->idlenessWatcherGroupBox->setChecked(mSettings.isIdlenessWatcherEnabled());
-    
+
     setComboBoxToValue(mUi->idleACActionComboBox, mSettings.getIdlenessACAction());
     mUi->idleACTimeEdit->setTime(mSettings.getIdlenessACTime());
-    
+
     setComboBoxToValue(mUi->idleBatteryActionComboBox, mSettings.getIdlenessBatteryAction());
     mUi->idleBatteryTimeEdit->setTime(mSettings.getIdlenessBatteryTime());
-    
+
     if(mBacklight->isBacklightAvailable()) {
         mUi->idlenessBacklightWatcherGroupBox->setChecked(mSettings.isIdlenessBacklightWatcherEnabled());
         mUi->idleTimeBacklightTimeEdit->setTime(mSettings.getIdlenessBacklightTime());
@@ -126,7 +126,7 @@ void IdlenessWatcherSettings::loadSettings()
 void IdlenessWatcherSettings::saveSettings()
 {
     mSettings.setIdlenessWatcherEnabled(mUi->idlenessWatcherGroupBox->isChecked());
-    
+
     mSettings.setIdlenessACAction(currentValue(mUi->idleACActionComboBox));
     mSettings.setIdlenessACTime(mUi->idleACTimeEdit->time());
 

--- a/config/idlenesswatchersettings.ui
+++ b/config/idlenesswatchersettings.ui
@@ -60,7 +60,17 @@
         <item row="1" column="1">
          <widget class="QTimeEdit" name="idleACTimeEdit">
           <property name="toolTip">
-           <string>Minutes:Seconds (min: 00:30)</string>
+           <string>Minutes:Seconds (min: 01:30)</string>
+          </property>
+          <property name="minimumDateTime">
+           <datetime>
+            <hour>0</hour>
+            <minute>1</minute>
+            <second>0</second>
+            <year>2000</year>
+            <month>1</month>
+            <day>1</day>
+           </datetime>
           </property>
           <property name="displayFormat">
            <string>mm:ss</string>
@@ -84,7 +94,17 @@
         <item row="3" column="1">
          <widget class="QTimeEdit" name="idleBatteryTimeEdit">
           <property name="toolTip">
-           <string>Minutes:Seconds (min: 00:30)</string>
+           <string>Minutes:Seconds (min: 01:30)</string>
+          </property>
+          <property name="minimumDateTime">
+           <datetime>
+            <hour>0</hour>
+            <minute>1</minute>
+            <second>0</second>
+            <year>2000</year>
+            <month>1</month>
+            <day>1</day>
+           </datetime>
           </property>
           <property name="displayFormat">
            <string>mm:ss</string>

--- a/config/powermanagementsettings.cpp
+++ b/config/powermanagementsettings.cpp
@@ -224,11 +224,13 @@ void PowerManagementSettings::setIdlenessACAction(int idlenessAction)
 
 QTime PowerManagementSettings::getIdlenessACTime()
 {
-    // defaults to 15 minutes (as before) and eventually load legacy value
-    int oldValue = value(QL1S("idlenessTimeSecs"), 900).toInt();
-    int m = oldValue % 60;
-    int s = oldValue / 60;
-    return value(IDLENESS_AC_TIME, QTime(m,s)).toTime();
+    // 1. The default value is 15 minutes (the legacy key is also read);
+    // 2. Intervals greater than or equal to one hour aren't supported; and
+    // 3. Intervals smaller than one minute are prevented.
+    int oldValue = qBound(60, value(QL1S("idlenessTimeSecs"), 900).toInt(), 3599);
+    int m = oldValue / 60;
+    int s = oldValue - m * 60;
+    return value(IDLENESS_AC_TIME, QTime(0, m, s)).toTime();
 }
 
 void PowerManagementSettings::setIdlenessACTime(QTime idlenessTime)
@@ -250,11 +252,13 @@ void PowerManagementSettings::setIdlenessBatteryAction(int idlenessAction)
 
 QTime PowerManagementSettings::getIdlenessBatteryTime()
 {
-    // defaults to 15 minutes (as before) and eventually load legacy value
-    int oldValue = value(QL1S("idlenessTimeSecs"), 900).toInt();
-    int m = oldValue % 60;
-    int s = oldValue / 60;
-    return value(IDLENESS_BATTERY_TIME, QTime(m,s)).toTime();
+    // 1. The default value is 15 minutes (the legacy key is also read);
+    // 2. Intervals greater than or equal to one hour aren't supported; and
+    // 3. Intervals smaller than one minute are prevented.
+    int oldValue = qBound(60, value(QL1S("idlenessTimeSecs"), 900).toInt(), 3599);
+    int m = oldValue / 60;
+    int s = oldValue - m * 60;
+    return value(IDLENESS_BATTERY_TIME, QTime(0, m, s)).toTime();
 }
 
 void PowerManagementSettings::setIdlenessBatteryTime(QTime idlenessTime)


### PR DESCRIPTION
It was misread by https://github.com/lxqt/lxqt-powermanagement/commit/8140ef538ee7e65ff7b51b293194e6dee45011c5

I also changed the signal `timeChanged` to `editingFinished` for time-edits to prevent a continuous writing to the config file when the user changes the time with mouse wheel.

Fixes https://github.com/lxqt/lxqt-powermanagement/issues/238