### PR TITLE
small fixes

### DIFF
--- a/config/idlenesswatchersettings.ui
+++ b/config/idlenesswatchersettings.ui
@@ -80,14 +80,14 @@
         <item row="2" column="0">
          <widget class="QLabel" name="idleTimeBatteryLabel">
           <property name="text">
-           <string>When idle on Battery</string>
+           <string>When idle on Battery:</string>
           </property>
          </widget>
         </item>
         <item row="3" column="0">
          <widget class="QLabel" name="idleBatteryActionLabel">
           <property name="text">
-           <string>Battery Idle time</string>
+           <string>Battery Idle time:</string>
           </property>
          </widget>
         </item>

--- a/config/lidwatchersettings.ui
+++ b/config/lidwatchersettings.ui
@@ -35,7 +35,7 @@ padding-top: 30px;
          <string notr="true"/>
         </property>
         <property name="title">
-         <string>Action when lid is closed</string>
+         <string>Action when lid is closed:</string>
         </property>
         <layout class="QFormLayout" name="formLayout_2">
          <property name="fieldGrowthPolicy">
@@ -47,7 +47,7 @@ padding-top: 30px;
          <item row="0" column="0">
           <widget class="QLabel" name="onBatteryActionLabel">
            <property name="text">
-            <string>On Battery</string>
+            <string>On Battery:</string>
            </property>
           </widget>
          </item>
@@ -78,7 +78,7 @@ padding-top: 30px;
          <item row="1" column="0">
           <widget class="QLabel" name="onAcActionLabel">
            <property name="text">
-            <string>On AC</string>
+            <string>On AC:</string>
            </property>
           </widget>
          </item>
@@ -112,7 +112,7 @@ padding-top: 30px;
             </sizepolicy>
            </property>
            <property name="text">
-            <string>On Battery</string>
+            <string>On Battery:</string>
            </property>
           </widget>
          </item>
@@ -122,7 +122,7 @@ padding-top: 30px;
          <item row="2" column="0">
           <widget class="QLabel" name="extMonOnAcActionLabel">
            <property name="text">
-            <string>On AC</string>
+            <string>On AC:</string>
            </property>
           </widget>
          </item>

--- a/config/powerkeyssettings.ui
+++ b/config/powerkeyssettings.ui
@@ -23,7 +23,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="powerKeyLabel">
         <property name="text">
-         <string>Power Key Action</string>
+         <string>Power Key Action:</string>
         </property>
        </widget>
       </item>
@@ -39,14 +39,14 @@
       <item row="1" column="0">
        <widget class="QLabel" name="suspendKeyLabel">
         <property name="text">
-         <string>Suspend Key Action</string>
+         <string>Suspend Key Action:</string>
         </property>
        </widget>
       </item>
       <item row="2" column="0">
        <widget class="QLabel" name="hibernateKeyLabel">
         <property name="text">
-         <string>Hibernate Key Action</string>
+         <string>Hibernate Key Action:</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Added missing colons and removed redundant AC/Battery, "AC" can be real long in other languages.