### PR TITLE
Allow pausing of idleness checks from tray icon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" O
 
 set(KF5_MINIMUM_VERSION "5.36.0")
 set(LXQT_MINIMUM_VERSION "0.17.0")
-set(QT_MINIMUM_VERSION "5.12.0")
+set(QT_MINIMUM_VERSION "5.15.0")
 
 find_package(Qt5DBus ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt5LinguistTools ${QT_MINIMUM_VERSION} REQUIRED)

--- a/config/powermanagementsettings.cpp
+++ b/config/powermanagementsettings.cpp
@@ -29,6 +29,9 @@
 
 #include "powermanagementsettings.h"
 
+// the pause state is only for the tray icon and is not saved
+bool PowerManagementSettings::mIdlenessWatcherPaused = false;
+
 namespace PowerManagementSettingsConstants
 {
     const QString RUN_CHECK_LEVEL { QSL("runCheckLevel") };
@@ -345,5 +348,14 @@ int PowerManagementSettings::getHibernateKeyAction()
 void PowerManagementSettings::setHibernateKeyAction(int action)
 {
     setValue(HIBERNATE_KEY_ACTION, action);
+}
+
+bool PowerManagementSettings::isIdlenessWatcherPaused() const
+{
+    return mIdlenessWatcherPaused;
+}
+
+void PowerManagementSettings::setIdlenessWatcherPaused(bool idlenessWatcherPaused) {
+    mIdlenessWatcherPaused = idlenessWatcherPaused;
 }
 

--- a/config/powermanagementsettings.h
+++ b/config/powermanagementsettings.h
@@ -115,12 +115,18 @@ public:
 
     int getPowerKeyAction();
     void setPowerKeyAction(int action);
-    
+
     int getSuspendKeyAction();
     void setSuspendKeyAction(int action);
-    
+
     int getHibernateKeyAction();
     void setHibernateKeyAction(int action);
+
+    bool isIdlenessWatcherPaused() const;
+    void setIdlenessWatcherPaused(bool idlenessWatcherPaused);
+
+private:
+    static bool mIdlenessWatcherPaused;
 };
 
 

--- a/src/batterywatcher.h
+++ b/src/batterywatcher.h
@@ -32,6 +32,8 @@
 #include "batteryinfodialog.h"
 #include "../config/powermanagementsettings.h"
 
+#include <QTimer>
+
 #include <Solid/Battery>
 
 class BatteryWatcher : public Watcher
@@ -45,10 +47,13 @@ public:
 private slots:
     void batteryChanged();
     void settingsChanged();
+    void onPauseTimeout();
+    void setPause(TrayIcon::PAUSE duration);
 
 private:
     QList<Solid::Battery*> mBatteries;
     QList<TrayIcon*> mTrayIcons;
+    QTimer mPauseTimer;
 
     PowerManagementSettings mSettings;
     BatteryInfoDialog *mBatteryInfoDialog;

--- a/src/idlenesswatcher.cpp
+++ b/src/idlenesswatcher.cpp
@@ -113,6 +113,13 @@ void IdlenessWatcher::setup()
 
 void IdlenessWatcher::timeoutReached(int identifier,int /*msec*/)
 {
+    if (mPSettings.isIdlenessWatcherPaused()) {
+        QTimer::singleShot(0, this, [] {
+            KIdleTime::instance()->simulateUserActivity();
+        });
+        return;
+    }
+
     // check if disable Idleness when fullscreen is enabled
     if (mPSettings.isDisableIdlenessWhenFullscreenEnabled()) {
         WId w = KWindowSystem::activeWindow();

--- a/src/trayicon.h
+++ b/src/trayicon.h
@@ -40,11 +40,25 @@ class TrayIcon : public QSystemTrayIcon
     Q_OBJECT
 
 public:
+    enum PAUSE {
+        None  = 0,
+        Half  = 1,
+        One   = 2, // two halves
+        Two   = 4,
+        Three = 6,
+        Four  = 8
+    };
+
     TrayIcon(Solid::Battery *battery, QObject *parent = nullptr);
     ~TrayIcon() override;
 
+    static int getPauseInterval(PAUSE duration);
+
+    void setPause(PAUSE duration);
+
 signals:
     void toggleShowInfo();
+    void pauseChanged(PAUSE duration);
 
 public slots:
     void iconChanged();
@@ -52,14 +66,19 @@ public slots:
 
 private slots:
     void onConfigureTriggered();
+    void onPauseTriggered(QAction *action);
     void onAboutTriggered();
     void onDisableIconTriggered();
     void onActivated(QSystemTrayIcon::ActivationReason reason);
 
 private:
+    QIcon emblemizedIcon();
+
     Solid::Battery *mBattery;
     IconProducer mIconProducer;
     QMenu mContextMenu;
+    QActionGroup *mPauseActions;
+    bool mHasPauseEmblem;
 };
 
 #endif // TRAYICON_H


### PR DESCRIPTION
 * 5 pause intervals are added to a new menu inside the tray context menu: 30 min. and 1-4 hours.
 * When the user pauses idleness checks, a pause emblem appears on the tray icon. It'll be removed if the pause interval ends or the user unchecks it.
 * The pause state will be automatically removed if the user disabled the tray icon.
 * The pause state is only for the current session; it isn't saved/remembered for the next session.

Closes https://github.com/lxqt/lxqt-powermanagement/issues/253

NOTE: `QT_MINIMUM_VERSION` is bumped to 5.15.0 because 5.14.0 was needed by a function. Also see https://github.com/lxqt/lxqt/discussions/1974