### PR TITLE
Prevent high memory usage by tray icon

### DIFF
--- a/src/iconproducer.h
+++ b/src/iconproducer.h
@@ -36,7 +36,7 @@ public slots:
 
 private:
 
-    QIcon &generatedIcon();
+    QIcon generatedIcon();
     template <int iconType>
         QString buildIcon(Solid::Battery::ChargeState state, int chargeLevel);
 


### PR DESCRIPTION
The handmade cache had no limit and could cause a situation like a memory leak (although, it wasn't a real leak). `QPixmapCache` is used instead.

In addition, this patch fixes https://github.com/lxqt/lxqt-powermanagement/issues/298. I didn't have time to explore the reason but it's safer to use `QPixmapCache`.