### PR TITLE
Better tray icon descriptions

### DIFF
--- a/config/batterywatchersettings.cpp
+++ b/config/batterywatchersettings.cpp
@@ -41,8 +41,8 @@ static inline void fillIconTypeCombo(QComboBox* comboBox)
     comboBox->addItem(BatteryWatcherSettings::tr("from theme", "icons"), PowerManagementSettings::ICON_THEME);
     comboBox->addItem(BatteryWatcherSettings::tr("Circle", "icons"), PowerManagementSettings::ICON_CIRCLE);
     comboBox->addItem(BatteryWatcherSettings::tr("Circle with percentage", "icons"), PowerManagementSettings::ICON_CIRCLE_ENHANCED);
-    comboBox->addItem(BatteryWatcherSettings::tr("Battery with percentage", "icons"), PowerManagementSettings::ICON_BATTERY);
-    comboBox->addItem(BatteryWatcherSettings::tr("Battery with percentage, opaque", "icons"), PowerManagementSettings::ICON_BATTERY_OPAQUE);
+    comboBox->addItem(BatteryWatcherSettings::tr("Battery with percentage and background", "icons"), PowerManagementSettings::ICON_BATTERY);
+    comboBox->addItem(BatteryWatcherSettings::tr("Battery with percentage", "icons"), PowerManagementSettings::ICON_BATTERY_OPAQUE);
 }
 
 BatteryWatcherSettings::BatteryWatcherSettings(QWidget *parent) :


### PR DESCRIPTION
The visible difference between the two battery icons is the existence or absence of a (translucent) white background. The word "opaque" was confusing.

So, the icon descriptions are changed to "Battery with percentage and background" and "Battery with percentage".

Closes https://github.com/lxqt/lxqt-powermanagement/issues/317