### PR TITLE
Fix desktop file

### DIFF
--- a/config/lxqt-config-powermanagement.desktop.in
+++ b/config/lxqt-config-powermanagement.desktop.in
@@ -2,7 +2,7 @@
 Type=Application
 Exec=lxqt-config-powermanagement
 Icon=preferences-system-power-management
-Categories=Settings;DesktopSettings;Qt;LXQt;
+Categories=Settings;DesktopSettings;Qt;
 OnlyShowIn=LXQt;
 
 #TRANSLATIONS_DIR=translations


### PR DESCRIPTION
desktop-file-validate: "Categories" in group "Desktop Entry" contains an unregistered value "LXQt"