### PR TITLE
Consider stable state of battery

### DIFF
--- a/src/batteryhelper.cpp
+++ b/src/batteryhelper.cpp
@@ -41,7 +41,7 @@ QString BatteryHelper::stateToString(Solid::Battery::ChargeState state)
     switch (state)
     {
     case Solid::Battery::NoCharge:
-        return tr("Empty");
+        return tr("Stable");
     case Solid::Battery::Discharging:
         return tr("Discharging");
     case Solid::Battery::FullyCharged:

--- a/src/batteryinfoframe.cpp
+++ b/src/batteryinfoframe.cpp
@@ -61,7 +61,8 @@ BatteryInfoFrame::~BatteryInfoFrame()
 
 void BatteryInfoFrame::onBatteryChanged()
 {
-    mUi->stateValue->setText(BatteryHelper::stateToString(mBattery->chargeState()));
+    mUi->stateValue->setText(mBattery->chargePercent() <= 0 && mBattery->chargeState() == Solid::Battery::NoCharge ?
+                             tr("Empty") : BatteryHelper::stateToString(mBattery->chargeState()));
     mUi->energyFullValue->setText(QString::fromLatin1("%1 Wh (%2 %)").arg(mBattery->energyFull(), 0, 'f', 2).arg(mBattery->capacity()));
     mUi->energyValue->setText(QString::fromLatin1("%1 Wh (%2 %)").arg(mBattery->energy(), 0, 'f', 2).arg(mBattery->chargePercent()));
     mUi->energyRateValue->setText(QString::fromLatin1("%1 W").arg(mBattery->energyRate(), 0, 'f', 2));

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -158,7 +158,9 @@ QIcon TrayIcon::emblemizedIcon()
 
 void TrayIcon::updateTooltip()
 {
-    QString tooltip = BatteryHelper::stateToString(mBattery->chargeState()) % QString::fromLatin1(" (%1%)").arg(mBattery->chargePercent());
+    QString stateStr = mBattery->chargePercent() <= 0 && mBattery->chargeState() == Solid::Battery::NoCharge ?
+                       tr("Empty") : BatteryHelper::stateToString(mBattery->chargeState());
+    QString tooltip = stateStr % QString::fromLatin1(" (%1%)").arg(mBattery->chargePercent());
     switch (mBattery->chargeState())
     {
         case Solid::Battery::Charging:


### PR DESCRIPTION
`Solid::Battery::NoCharge` is interpreted as "Stable", not "Empty". "Empty" is used only when a completely empty battery is in the stable state (i.e., it isn't charging).

The "charge emblem" isn't shown in the stable state because there's no charging in this state. Moreover, the info we get is about the battery, not the adapter connection.

Closes https://github.com/lxqt/lxqt-powermanagement/issues/295