### PR TITLE
Override DPMS on enabling idleness watcher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,18 +15,22 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" OFF)
 
+set(LXQTBT_MINIMUM_VERSION "0.13.0")
 set(KF5_MINIMUM_VERSION "5.101.0")
 set(LXQT_MINIMUM_VERSION "1.3.0")
 set(QT_MINIMUM_VERSION "5.15.0")
 
+find_package(lxqt-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt5DBus ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt5LinguistTools ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt5Svg ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt5Widgets ${QT_MINIMUM_VERSION} REQUIRED)
+find_package(Qt5X11Extras ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(KF5IdleTime ${KF5_MINIMUM_VERSION} REQUIRED)
 find_package(KF5Solid ${KF5_MINIMUM_VERSION} REQUIRED)
 find_package(lxqt ${LXQT_MINIMUM_VERSION} REQUIRED)
 find_package(lxqt-globalkeys-ui ${LXQT_GLOBALKEYS_MINIMUM_VERSION} REQUIRED)
+find_package(XCB REQUIRED COMPONENTS xcb-dpms)
 
 message(STATUS "Building with Qt${Qt5Core_VERSION}")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,8 @@ target_link_libraries(lxqt-powermanagement
     KF5::Solid
     KF5::IdleTime
     lxqt-globalkeys
+    Qt5::X11Extras
+    ${XCB_LIBRARIES}
 )
 
 install(TARGETS

--- a/src/idlenesswatcher.h
+++ b/src/idlenesswatcher.h
@@ -45,6 +45,8 @@ private Q_SLOTS:
     void onSettingsChanged();
 
 private:
+    void setDpmsTimeouts(bool restore);
+
     PowerManagementSettings mPSettings;
     int mIdleACWatcher;
     int mIdleBatteryWatcher;
@@ -52,6 +54,7 @@ private:
     LXQt::Backlight *mBacklight;
     int mBacklightActualValue;
     bool mDischarging;
+    quint16 mDpmsStandby, mDpmsSuspend, mDpmsOff;
 };
 
 #endif // IDLENESSWATCHER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,7 @@
 int main(int argc, char *argv[])
 {
 
-    LXQt::Application a(argc, argv);
+    LXQt::Application a(argc, argv, true);
     a.setQuitOnLastWindowClosed(false);
 
     QCommandLineParser parser;


### PR DESCRIPTION
The patch disables DPMS when the idle watcher is enabled, by giving it three zero values, as some LXQt users might have done manually (me included).

It also restores its original timeouts when the idle watcher is disabled.

Fixes https://github.com/lxqt/lxqt-powermanagement/issues/374