### PR TITLE
Also suspend screensaver when idle watcher is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ find_package(KF5IdleTime ${KF5_MINIMUM_VERSION} REQUIRED)
 find_package(KF5Solid ${KF5_MINIMUM_VERSION} REQUIRED)
 find_package(lxqt ${LXQT_MINIMUM_VERSION} REQUIRED)
 find_package(lxqt-globalkeys-ui ${LXQT_GLOBALKEYS_MINIMUM_VERSION} REQUIRED)
-find_package(XCB REQUIRED COMPONENTS xcb-dpms)
+find_package(XCB REQUIRED COMPONENTS xcb-dpms xcb-screensaver)
 
 message(STATUS "Building with Qt${Qt5Core_VERSION}")
 

--- a/src/idlenesswatcher.cpp
+++ b/src/idlenesswatcher.cpp
@@ -37,6 +37,7 @@
 #include <QObject>
 #include <QX11Info>
 #include <xcb/dpms.h>
+#include <xcb/screensaver.h>
 
 IdlenessWatcher::IdlenessWatcher(QObject* parent):
     Watcher(parent)
@@ -95,11 +96,14 @@ IdlenessWatcher::~IdlenessWatcher()
 
 void IdlenessWatcher::setDpmsTimeouts(bool restore) {
     if (QGuiApplication::platformName() == QStringLiteral("xcb")) {
+        xcb_connection_t* c = QX11Info::connection();
         if (restore) {
-            xcb_dpms_set_timeouts(QX11Info::connection(), mDpmsStandby, mDpmsSuspend, mDpmsOff);
+            xcb_dpms_set_timeouts(c, mDpmsStandby, mDpmsSuspend, mDpmsOff);
+            xcb_screensaver_suspend(c, 0); // WARNING: This is not documented but works.
         }
         else {
-            xcb_dpms_set_timeouts(QX11Info::connection(), 0, 0, 0);
+            xcb_dpms_set_timeouts(c, 0, 0, 0);
+            xcb_screensaver_suspend(c, XCB_SCREENSAVER_SUSPEND);
         }
     }
 }


### PR DESCRIPTION
Without this, the screensaver timeout will kick in and interfere with our daemon. The suspension will be reverted when the idle watcher is disabled or the daemon is stopped.

Fixes https://github.com/lxqt/lxqt-powermanagement/issues/374 completely