### PR TITLE
Removed "Ask" option from lid and idle watchers

### DIFF
--- a/config/batterywatchersettings.cpp
+++ b/config/batterywatchersettings.cpp
@@ -54,7 +54,7 @@ BatteryWatcherSettings::BatteryWatcherSettings(QWidget *parent) :
 
 {
     mUi->setupUi(this);
-    fillComboBox(mUi->actionComboBox);
+    fillComboBox(mUi->actionComboBox, true);
     fillIconTypeCombo(mUi->iconTypeComboBox);
     mUi->chargeLevelSlider->setValue(53);
     mChargingIconProducer.updateState(Solid::Battery::Charging);

--- a/config/helpers.cpp
+++ b/config/helpers.cpp
@@ -29,11 +29,14 @@
 
 #include "helpers.h"
 
-void fillComboBox(QComboBox* comboBox)
+void fillComboBox(QComboBox* comboBox, bool ask)
 {
     comboBox->clear();
     comboBox->addItem(QObject::tr("Nothing"), -1);
-    comboBox->addItem(QObject::tr("Ask"), LXQt::Power::PowerShowLeaveDialog);
+    if (ask)
+    {
+        comboBox->addItem(QObject::tr("Ask"), LXQt::Power::PowerShowLeaveDialog);
+    }
     comboBox->addItem(QObject::tr("Lock screen"), -2); // FIXME
     comboBox->addItem(QObject::tr("Suspend"), LXQt::Power::PowerSuspend);
     comboBox->addItem(QObject::tr("Hibernate"), LXQt::Power::PowerHibernate);

--- a/config/helpers.h
+++ b/config/helpers.h
@@ -10,7 +10,7 @@
 
 #include <QComboBox>
 
-void fillComboBox(QComboBox* comboBox);
+void fillComboBox(QComboBox* comboBox, bool ask = false);
 
 void setComboBoxToValue(QComboBox* comboBox, int value);
 

--- a/config/powerkeyssettings.cpp
+++ b/config/powerkeyssettings.cpp
@@ -35,9 +35,9 @@ PowerKeysSettings::PowerKeysSettings(QWidget *parent) :
     mUi(new Ui::PowerKeysSettings)
 {
     mUi->setupUi(this);
-    fillComboBox(mUi->powerKeyActionComboBox);
-    fillComboBox(mUi->suspendKeyActionComboBox);
-    fillComboBox(mUi->hibernateKeyActionComboBox);
+    fillComboBox(mUi->powerKeyActionComboBox, true);
+    fillComboBox(mUi->suspendKeyActionComboBox, true);
+    fillComboBox(mUi->hibernateKeyActionComboBox, true);
 
     connect(mUi->powerKeyActionComboBox, QOverload<int>::of(&QComboBox::activated), this, &PowerKeysSettings::saveSettings);
     connect(mUi->suspendKeyActionComboBox, QOverload<int>::of(&QComboBox::activated), this, &PowerKeysSettings::saveSettings);


### PR DESCRIPTION
Because it didn't make sense in them.

The "Ask" option is kept untouched in the battery and power watchers.

Closes https://github.com/lxqt/lxqt-powermanagement/issues/254