### PR TITLE
Show a notification when the battery is present, not absent

### DIFF
--- a/src/batterywatcher.h
+++ b/src/batterywatcher.h
@@ -51,6 +51,8 @@ private slots:
     void setPause(TrayIcon::PAUSE duration);
 
 private:
+    void chargeLevelAndStatus(bool &discharging, double &chargeLevel);
+
     QList<Solid::Battery*> mBatteries;
     QList<TrayIcon*> mTrayIcons;
     QTimer mPauseTimer;


### PR DESCRIPTION
In virtual machines especially, it is odd to see a message about the battery not being present. This commit moves that message to only display when there *is* a battery present.

The code is still slightly rough, but I'd like thoughts on the general idea.

Thanks.