### PR TITLE
Make idle tooltip descriptions more accurate

### DIFF
--- a/config/idlenesswatchersettings.ui
+++ b/config/idlenesswatchersettings.ui
@@ -60,7 +60,7 @@
         <item row="1" column="1">
          <widget class="QTimeEdit" name="idleACTimeEdit">
           <property name="toolTip">
-           <string>Minutes:Seconds (min: 01:30)</string>
+           <string>Minutes:Seconds (Minimum: 00:30)</string>
           </property>
           <property name="minimumDateTime">
            <datetime>
@@ -94,7 +94,7 @@
         <item row="3" column="1">
          <widget class="QTimeEdit" name="idleBatteryTimeEdit">
           <property name="toolTip">
-           <string>Minutes:Seconds (min: 01:30)</string>
+           <string>Minutes:Seconds (Minimum: 00:30)</string>
           </property>
           <property name="minimumDateTime">
            <datetime>


### PR DESCRIPTION
In the code, and in the GUI (with some effort), the minimum duration is 0m30s.

It has been proposed https://github.com/lxqt/lxqt-powermanagement/issues/387 https://github.com/lxqt/lxqt-powermanagement/issues/430 to change to Hours:Minutes or Hours:Minutes:Seconds.