### PR TITLE
Added dpms command for Hyprland

### DIFF
--- a/config/idlenesswatchersettings.cpp
+++ b/config/idlenesswatchersettings.cpp
@@ -59,6 +59,7 @@ IdlenessWatcherSettings::IdlenessWatcherSettings(QWidget *parent) :
     // Handle the monitor command separately.
     if (QGuiApplication::platformName() == QStringLiteral("wayland")) {
         // Add some known commands that work fine.
+        mUi->monitorComboBox->addItem(QStringLiteral("Hyprland"), QStringLiteral("hyprctl dispatch dpms off"));
         mUi->monitorComboBox->addItem(QStringLiteral("KWin-Wayland"), QStringLiteral("kscreen-doctor --dpms off"));
         mUi->monitorComboBox->addItem(QStringLiteral("Niri"), QStringLiteral("niri msg action power-off-monitors"));
     }


### PR DESCRIPTION
With 
```
misc {
    ...
    mouse_move_enables_dpms=true
    key_press_enables_dpms=true
}
```
in the hyrpland config power on works, the external one powers on at awake/lid opening, the internal on the first keypress or mousemovement. 

~There is one strange fact: when the powermanagement settings window is open on the external monitor it doesn't poweroff on idle, need to check that with other compositors.~ has to have another reason, sometimes the external doesn't poweroff on my account.